### PR TITLE
Add Password Masking and Content Hiding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
 # screenlock_koreader_plugin
 This is a small plugin to enable locking the screen of the KOReader.
 
-Just put screenlock.koplugin into the kodreader/plugins directory.
-
-Change the hardcoded password at the top of the main.lua from 1234 to something else.
+## Setup
+1. Put `screenlock.koplugin` into the `kodreader/plugins` directory.
+2. Change the hardcoded password at the top of the main.lua from 1234 to something else.
 
 The plugin will automatically activate on resume from suspend. There is also a screenlock menu entry added.
+
+### Hide Content Feature
+Change `hide_content` bool to `true` to enlarge the input box and hide the screen until the password is entered correctly. This stops unauthorized users from seeing what books you're reading even if they turn on the device. Set bool to `false` to return to the small password box.
+
+> [!CAUTION]  
+> This plugin is made for basic protection, not security — it may not protect your device from an experienced attacker.
+>
+> Always keep your device out of the hands of real threats.

--- a/screenlock.koplugin/main.lua
+++ b/screenlock.koplugin/main.lua
@@ -63,6 +63,7 @@ function ScreenLock:showPasswordPrompt()
         title           = _("Enter Password"),
         input           = "",
         maskinput       = true,
+        text_type = "password",
         hint            = _("Password"),
         fullscreen      = self.hide_content,        -- request full screen mode
         use_available_height = self.hide_content,   -- use available screen height even when keyboard is shown

--- a/screenlock.koplugin/main.lua
+++ b/screenlock.koplugin/main.lua
@@ -12,6 +12,7 @@ local ScreenLock = WidgetContainer:extend{
 
     locked   = false,      -- Track locked state
     password = "1234",     -- Your hard-coded password
+    hide_content = true,   -- Hide screen content before password is entered
 }
 
 ------------------------------------------------------------------------------
@@ -59,49 +60,46 @@ end
 function ScreenLock:showPasswordPrompt()
     local dialog
     dialog = InputDialog:new{
-        title     = _("Enter Password"),
-        input     = "",
-        maskinput = true,
-        hint      = _("Password"),
-        buttons   = {
+        title           = _("Enter Password"),
+        input           = "",
+        maskinput       = true,
+        hint            = _("Password"),
+        fullscreen      = self.hide_content,        -- request full screen mode
+        use_available_height = self.hide_content,   -- use available screen height even when keyboard is shown
+        buttons         = {
             {
-                -- CANCEL => Reopen dialog (cannot escape)
                 {
                     text = _("Cancel"),
                     callback = function()
                         UIManager:show(
                             InfoMessage:new{
                                 text = _("You must enter the correct password!"),
-                                timeout = 1    -- Dismiss after 1 second
+                                timeout = 1
                             }
                         )
                         UIManager:close(dialog)
-                        -- Reopen the password prompt
                         self:showPasswordPrompt()
                     end
                 },
-                -- OK => Check password
                 {
                     text = _("OK"),
                     is_enter_default = true,
                     callback = function()
                         local userInput = dialog:getInputText()
                         if userInput == self.password then
-                            -- Correct => Unlock and show success InfoMessage
                             self.locked = false
                             UIManager:close(dialog)
                             UIManager:show(
                                 InfoMessage:new{
-                                    text    = _("Screen unlocked."),
-                                    timeout = 1    -- Dismiss after 1 second
+                                    text = _("Screen unlocked."),
+                                    timeout = 1
                                 }
                             )
                         else
-                            -- Wrong => Show error InfoMessage and re-display prompt
                             UIManager:show(
                                 InfoMessage:new{
-                                    text    = _("Wrong password! Try again."),
-                                    timeout = 1    -- Dismiss after 1 second
+                                    text = _("Wrong password! Try again."),
+                                    timeout = 1
                                 }
                             )
                             UIManager:close(dialog)
@@ -112,7 +110,6 @@ function ScreenLock:showPasswordPrompt()
             }
         },
     }
-
     UIManager:show(dialog)
     dialog:onShowKeyboard()  -- Immediately open the on-screen keyboard
 end
@@ -138,4 +135,3 @@ function ScreenLock:addToMainMenu(menu_items)
 end
 
 return ScreenLock
-


### PR DESCRIPTION
- Adds the ability to mask your password from prying eyes while typing.
- Adds ability to toggle "content hiding" which covers the screen with the password box until the correct password has been entered. This stops unauthorized users from seeing what books you're reading without the proper password.
- Updates README to reflect changes and provide password warning.